### PR TITLE
Add extra workload types

### DIFF
--- a/charts/base/Chart.yaml
+++ b/charts/base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: base
 description: Base Helm chart for Kubernetes - fully values-driven.
 type: application
-version: 0.1.1
+version: 0.2.0
 maintainers:
   - name: bonddim
 sources:

--- a/charts/base/README.md
+++ b/charts/base/README.md
@@ -1,6 +1,6 @@
 # base
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Base Helm chart for Kubernetes - fully values-driven.
 
@@ -36,10 +36,16 @@ Base Helm chart for Kubernetes - fully values-driven.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| annotations | object | `{}` | Additional annotations on the Deployment resource itself. |
+| workload | string | `"deployment"` | Workload type to deploy. One of: deployment, daemonset, statefulset, pod or null |
+| annotations | object | `{}` | Additional annotations on the Workload resource itself. |
 | labels | object | `{}` | Additional labels on the Deployment resource itself. |
 | replicas | int | `nil` | Number of pod replicas. Ignored when autoscaling.enabled=true. Must be >= 0 if specified. null by default, which defaults to 1 and not controlled by Helm. |
 | strategy | object | `{}` | Deployment update strategy. e.g. { type: RollingUpdate, rollingUpdate: { maxSurge: 1, maxUnavailable: 0 } } |
+| updateStrategy | object | `{}` | DaemonSet/StatefulSet update strategy. e.g. { type: RollingUpdate } or { type: OnDelete } |
+| serviceName | string | `""` | StatefulSet service name. Defaults to the fullname when empty. |
+| podManagementPolicy | string | `""` | StatefulSet pod management policy: OrderedReady or Parallel. |
+| volumeClaimTemplates | list | `[]` | StatefulSet volumeClaimTemplates for persistent storage. |
+| persistentVolumeClaimRetentionPolicy | object | `{}` | StatefulSet persistentVolumeClaimRetentionPolicy. |
 | revisionHistoryLimit | int | `nil` | Number of old ReplicaSets to retain. |
 | podAnnotations | object | `{}` | Additional annotations on the Pod template. |
 | podLabels | object | `{}` | Additional labels on the Pod template. |

--- a/charts/base/templates/daemonset.yaml
+++ b/charts/base/templates/daemonset.yaml
@@ -1,6 +1,6 @@
-{{- if eq .Values.workload "deployment" -}}
+{{- if eq .Values.workload "daemonset" -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   {{- with include "base.annotations" (dict "annotations" .Values.annotations "context" .) }}
   annotations: {{- . | nindent 4 }}
@@ -8,16 +8,13 @@ metadata:
   labels: {{- include "base.labels" (dict "labels" .Values.labels "context" .) | nindent 4 }}
   name: {{ include "base.fullname" . }}
 spec:
-  {{- if and (not .Values.autoscaling.enabled) (ge (int .Values.replicas) 0) }}
-  replicas: {{ .Values.replicas }}
-  {{- end }}
   {{- with .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ . }}
   {{- end }}
   selector:
     matchLabels: {{- include "base.selectorLabels" . | nindent 6 }}
-  {{- with .Values.strategy }}
-  strategy: {{- toYaml . | nindent 4 }}
+  {{- with .Values.updateStrategy }}
+  updateStrategy: {{- toYaml . | nindent 4 }}
   {{- end }}
   template: {{- include "base.podTemplate" . | nindent 4 }}
 {{- end }}

--- a/charts/base/templates/pod.yaml
+++ b/charts/base/templates/pod.yaml
@@ -1,0 +1,12 @@
+{{- if eq .Values.workload "pod" -}}
+{{- $podTemplate := include "base.podTemplate" . | fromYaml -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  {{- with $podTemplate.metadata.annotations }}
+  annotations: {{- . | nindent 4 }}
+  {{- end }}
+  labels: {{- $podTemplate.metadata.labels | toYaml | nindent 4 }}
+  name: {{ include "base.fullname" . }}
+spec: {{- $podTemplate.spec | toYaml | nindent 2 }}
+{{- end }}

--- a/charts/base/templates/statefulset.yaml
+++ b/charts/base/templates/statefulset.yaml
@@ -1,6 +1,6 @@
-{{- if eq .Values.workload "deployment" -}}
+{{- if eq .Values.workload "statefulset" -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   {{- with include "base.annotations" (dict "annotations" .Values.annotations "context" .) }}
   annotations: {{- . | nindent 4 }}
@@ -16,8 +16,18 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{- include "base.selectorLabels" . | nindent 6 }}
-  {{- with .Values.strategy }}
-  strategy: {{- toYaml . | nindent 4 }}
+  serviceName: {{ default (include "base.fullname" .) .Values.serviceName }}
+  {{- with .Values.podManagementPolicy }}
+  podManagementPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.updateStrategy }}
+  updateStrategy: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml . | nindent 4 }}
   {{- end }}
   template: {{- include "base.podTemplate" . | nindent 4 }}
+  {{- with .Values.volumeClaimTemplates }}
+  volumeClaimTemplates: {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/base/values.yaml
+++ b/charts/base/values.yaml
@@ -32,7 +32,10 @@ commonAnnotations: {}
 ########################################################################
 ### Workload ###
 ########################################################################
-# -- Additional annotations on the Deployment resource itself.
+# -- Workload type to deploy. One of: deployment, daemonset, statefulset, pod or null
+# @section -- Workload parameters
+workload: deployment
+# -- Additional annotations on the Workload resource itself.
 # @section -- Workload parameters
 annotations: {}
 # -- Additional labels on the Deployment resource itself.
@@ -45,6 +48,21 @@ replicas: null
 # -- Deployment update strategy. e.g. { type: RollingUpdate, rollingUpdate: { maxSurge: 1, maxUnavailable: 0 } }
 # @section -- Workload parameters
 strategy: {}
+# -- DaemonSet/StatefulSet update strategy. e.g. { type: RollingUpdate } or { type: OnDelete }
+# @section -- Workload parameters
+updateStrategy: {}
+# -- (string) StatefulSet service name. Defaults to the fullname when empty.
+# @section -- Workload parameters
+serviceName: ""
+# -- (string) StatefulSet pod management policy: OrderedReady or Parallel.
+# @section -- Workload parameters
+podManagementPolicy: ""
+# -- StatefulSet volumeClaimTemplates for persistent storage.
+# @section -- Workload parameters
+volumeClaimTemplates: []
+# -- StatefulSet persistentVolumeClaimRetentionPolicy.
+# @section -- Workload parameters
+persistentVolumeClaimRetentionPolicy: {}
 # -- (int) Number of old ReplicaSets to retain.
 # @section -- Workload parameters
 revisionHistoryLimit: null


### PR DESCRIPTION
This pull request introduces significant enhancements to the `base` Helm chart, making it more flexible and extensible by supporting multiple Kubernetes workload types beyond just Deployments. The chart can now deploy DaemonSets, StatefulSets, and standalone Pods, with new configuration options for each workload type. The documentation and versioning have also been updated to reflect these improvements.

**Workload type support:**

* Added support for deploying `DaemonSet`, `StatefulSet`, and `Pod` resources in addition to `Deployment`, controlled by a new `workload` value in `values.yaml`. Corresponding templates for each workload type have been added (`daemonset.yaml`, `statefulset.yaml`, `pod.yaml`) and are conditionally rendered based on the `workload` value. [[1]](diffhunk://#diff-9d110e4c64ef7ed203592c2a9147f2830ed5addfc3c0187c079386a0d4ec8e14L35-R38) [[2]](diffhunk://#diff-9d110e4c64ef7ed203592c2a9147f2830ed5addfc3c0187c079386a0d4ec8e14R51-R65) [[3]](diffhunk://#diff-6ced286c291413dae68c8000b3f32d668307fe28c0134184b4124c8093d53d76R1-R12) [[4]](diffhunk://#diff-27121838a7f39d65080805971d07b0a820503d9092f729ffce9de50168fbcbcfR1-R33) [[5]](diffhunk://#diff-1689983d88cae0ce62b7d3bcc2a488446390160a1e9512d7216dac38301bc857R1-R20) [[6]](diffhunk://#diff-9096e2bc598221597b64ccef1f45ee075df2d700b13c29bc55a05b6c9fb763ddR1) [[7]](diffhunk://#diff-9096e2bc598221597b64ccef1f45ee075df2d700b13c29bc55a05b6c9fb763ddR23)

**StatefulSet-specific features:**

* Introduced new configuration options in `values.yaml` for StatefulSets, including `serviceName`, `podManagementPolicy`, `volumeClaimTemplates`, and `persistentVolumeClaimRetentionPolicy`, enabling advanced stateful workload management. [[1]](diffhunk://#diff-9d110e4c64ef7ed203592c2a9147f2830ed5addfc3c0187c079386a0d4ec8e14R51-R65) [[2]](diffhunk://#diff-27121838a7f39d65080805971d07b0a820503d9092f729ffce9de50168fbcbcfR1-R33)

**Configurable update strategies:**

* Added a generic `updateStrategy` value to support custom update strategies for DaemonSets and StatefulSets, in addition to the existing `strategy` for Deployments. [[1]](diffhunk://#diff-9d110e4c64ef7ed203592c2a9147f2830ed5addfc3c0187c079386a0d4ec8e14R51-R65) [[2]](diffhunk://#diff-27121838a7f39d65080805971d07b0a820503d9092f729ffce9de50168fbcbcfR1-R33) [[3]](diffhunk://#diff-1689983d88cae0ce62b7d3bcc2a488446390160a1e9512d7216dac38301bc857R1-R20)

**Documentation updates:**

* Updated `README.md` to document the new `workload` parameter and all additional configuration options for supported workload types, ensuring users understand the expanded capabilities.

**Versioning and metadata:**

* Bumped the chart version from `0.1.1` to `0.2.0` in both `Chart.yaml` and the version badge in `README.md` to reflect these breaking and additive changes. [[1]](diffhunk://#diff-d0fbf8c89b2099e782542c1c6b3abb9a9f71ada00b3ae34dc6f4bbd938ea174fL5-R5) [[2]](diffhunk://#diff-8f74505e1d48ae10edea77a862597aec96485c9b061e0af1fa52c96c61b8b500L3-R3)